### PR TITLE
Updating to work with Swift 5.8

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:4.0
+// swift-tools-version:4.2
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:4.2
+// swift-tools-version:5.8
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription
@@ -6,14 +6,13 @@ import PackageDescription
 let package = Package(
     name: "CodeRunnerCLI",
     dependencies: [
-        .package(url: "https://github.com/JohnSundell/Files", from: "1.9.0"),
-        .package(url: "https://github.com/JohnSundell/ShellOut", from: "1.0.0"),
-        .package(url: "https://github.com/JohnSundell/Require", from: "1.0.0")
+        .package(url: "https://github.com/JohnSundell/Files", from: "3.1.0"),
+        .package(url: "https://github.com/JohnSundell/ShellOut", from: "2.3.0"),
+        .package(url: "https://github.com/JohnSundell/Require", from: "2.0.0")
     ],
     targets: [
-        .target(name: "CodeRunnerCLI", dependencies: ["CodeRunnerCore"]),
+        .executableTarget(name: "CodeRunnerCLI", dependencies: ["CodeRunnerCore"]),
         .testTarget(name: "CodeRunnerCLITests", dependencies: ["CodeRunnerCore"]),
         .target(name: "CodeRunnerCore", dependencies: ["Files", "ShellOut", "Require"])
-    ],
-    swiftLanguageVersions: [4]
+    ]
 )

--- a/Sources/CodeRunnerCLI/main.swift
+++ b/Sources/CodeRunnerCLI/main.swift
@@ -9,7 +9,6 @@ import CodeRunnerCore
 
 if #available(OSX 10.11, *) {
     let tool = CommandLineTool()
-    
     do {
         try tool.run()
     } catch {

--- a/Sources/CodeRunnerCore/CommandLineTool.swift
+++ b/Sources/CodeRunnerCore/CommandLineTool.swift
@@ -14,15 +14,16 @@ public final class CommandLineTool {
     private let fileSystem = FileSystem()
     private let arguments: [String]
     private var path: String { return arguments[1] }
-    
     public init(arguments: [String] = CommandLine.arguments) {
         self.arguments = arguments
     }
     
     public func run() throws {
         do {
+            if arguments.count == 1 {
+                throw CLTError.missingPath
+            }
             let createdFilePath = try fileSystem.createItem(at: path)
-            print(createdFilePath)
             try shellOut(to: "open", arguments: ["-a CodeRunner", createdFilePath])
         }
     }

--- a/Sources/CodeRunnerCore/Enums.swift
+++ b/Sources/CodeRunnerCore/Enums.swift
@@ -18,6 +18,5 @@ public enum Kind {
 
 public enum CLTError: Error {
     case cannotCreateURL(path: String)
-    case missingFileName
-    case failedToCreateFile
+    case missingPath
 }

--- a/Sources/CodeRunnerCore/FileSystem+Creation.swift
+++ b/Sources/CodeRunnerCore/FileSystem+Creation.swift
@@ -12,7 +12,6 @@ import Files
 extension FileSystem {
     func createItem(at path: String) throws -> String {
         let kind = try itemKind(atPath: path)
-        
         switch kind {
         case .file:
             return try createFileIfNeeded(at: path).path
@@ -22,10 +21,12 @@ extension FileSystem {
     }
     
     private func itemKind(atPath path: String) throws -> Kind {
+        let fileManager = FileManager.default
         guard let item = URL(string: path) else {
             throw CLTError.cannotCreateURL(path: path)
         }
-        
-        return item.hasDirectoryPath ? .folder : .file
+        let lazyDirPath = item.appendingPathComponent("/")
+        let slashedIsDir = fileManager.fileExists(atPath: lazyDirPath.absoluteString)
+        return item.hasDirectoryPath||slashedIsDir ? .folder : .file
     }
 }


### PR DESCRIPTION
I had to update the dependencies to get it to compile—now working on MacOS 13, Swift 5.8. I also added a quick check to handle directory paths that are missing the trailing slash. The command line tool now throws a missing path error when invoked with no arguments